### PR TITLE
Make migrations easier by allowing cut and paste state height/round/s…

### DIFF
--- a/cmd/horcrux/cmd/config.go
+++ b/cmd/horcrux/cmd/config.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/url"
 	"os"
@@ -531,7 +530,7 @@ func (c RuntimeConfig) shareStateFile(chainID string) string {
 }
 
 func (c RuntimeConfig) writeConfigFile() error {
-	return ioutil.WriteFile(c.ConfigFile, c.Config.MustMarshalYaml(), 0644) //nolint
+	return os.WriteFile(c.ConfigFile, c.Config.MustMarshalYaml(), 0644) //nolint
 }
 
 type CosignerConfig struct {

--- a/cmd/horcrux/cmd/config_test.go
+++ b/cmd/horcrux/cmd/config_test.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -77,7 +77,7 @@ func TestConfigInitCmd(t *testing.T) {
 			require.NoError(t, err)
 
 			cmd := initCmd()
-			cmd.SetOutput(ioutil.Discard)
+			cmd.SetOutput(io.Discard)
 			cmd.SetArgs(tc.args)
 			err = cmd.Execute()
 
@@ -126,7 +126,7 @@ func TestConfigChainIDSetCmd(t *testing.T) {
 	require.NoError(t, err)
 
 	cmd := initCmd()
-	cmd.SetOutput(ioutil.Discard)
+	cmd.SetOutput(io.Discard)
 	cmd.SetArgs([]string{
 		chainID,
 		"tcp://10.168.0.1:1234",
@@ -159,7 +159,7 @@ func TestConfigChainIDSetCmd(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			cmd := setChainIDCmd()
-			cmd.SetOutput(ioutil.Discard)
+			cmd.SetOutput(io.Discard)
 			cmd.SetArgs(tc.args)
 			err := cmd.Execute()
 
@@ -186,7 +186,7 @@ func TestConfigNodesAddAndRemove(t *testing.T) {
 	require.NoError(t, err)
 
 	cmd := initCmd()
-	cmd.SetOutput(ioutil.Discard)
+	cmd.SetOutput(io.Discard)
 	cmd.SetArgs([]string{
 		chainID,
 		"tcp://10.168.0.1:1234",
@@ -304,7 +304,7 @@ func TestConfigNodesAddAndRemove(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			tc.cmd.SetOutput(ioutil.Discard)
+			tc.cmd.SetOutput(io.Discard)
 			tc.cmd.SetArgs(tc.args)
 			err = tc.cmd.Execute()
 
@@ -332,7 +332,7 @@ func TestConfigPeersAddAndRemove(t *testing.T) {
 	require.NoError(t, err)
 
 	cmd := initCmd()
-	cmd.SetOutput(ioutil.Discard)
+	cmd.SetOutput(io.Discard)
 	cmd.SetArgs([]string{
 		chainID,
 		"tcp://10.168.0.1:1234",
@@ -451,7 +451,7 @@ func TestConfigPeersAddAndRemove(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			tc.cmd.SetOutput(ioutil.Discard)
+			tc.cmd.SetOutput(io.Discard)
 			tc.cmd.SetArgs(tc.args)
 			err = tc.cmd.Execute()
 
@@ -611,7 +611,7 @@ func TestSetShares(t *testing.T) {
 	require.NoError(t, err)
 
 	cmd := initCmd()
-	cmd.SetOutput(ioutil.Discard)
+	cmd.SetOutput(io.Discard)
 	cmd.SetArgs([]string{
 		chainID,
 		"tcp://10.168.0.1:1234",
@@ -653,7 +653,7 @@ func TestSetShares(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			cmd := setSharesCmd()
-			cmd.SetOutput(ioutil.Discard)
+			cmd.SetOutput(io.Discard)
 			cmd.SetArgs(tc.args)
 			err = cmd.Execute()
 

--- a/cmd/horcrux/cmd/key2shares.go
+++ b/cmd/horcrux/cmd/key2shares.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/cmd/horcrux/cmd/root.go
+++ b/cmd/horcrux/cmd/root.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -61,7 +60,7 @@ func initConfig() {
 		return
 	}
 	handleInitError(viper.Unmarshal(&config.Config))
-	bz, err := ioutil.ReadFile(viper.ConfigFileUsed())
+	bz, err := os.ReadFile(viper.ConfigFileUsed())
 	handleInitError(err)
 	handleInitError(yaml.Unmarshal(bz, &config.Config))
 }

--- a/cmd/horcrux/cmd/state.go
+++ b/cmd/horcrux/cmd/state.go
@@ -1,18 +1,32 @@
 package cmd
 
 import (
+	"bufio"
 	"encoding/base64"
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/strangelove-ventures/horcrux/signer"
+
+	tmjson "github.com/tendermint/tendermint/libs/json"
 )
+
+// Snippet Taken from https://raw.githubusercontent.com/tendermint/tendermint/main/privval/file.go
+// FilePVLastSignState stores the mutable part of PrivValidator.
+type FilePVLastSignState struct {
+	Height int64 `json:"height"`
+	Round  int32 `json:"round"`
+	Step   int8  `json:"step"`
+}
 
 func init() {
 	stateCmd.AddCommand(showStateCmd())
 	stateCmd.AddCommand(setStateCmd())
+	stateCmd.AddCommand(importStateCmd())
 
 	rootCmd.AddCommand(stateCmd)
 }
@@ -96,8 +110,105 @@ func setStateCmd() *cobra.Command {
 				Signature: nil,
 				SignBytes: nil,
 			}
-			_ = pv.Save(signState, nil)
-			_ = share.Save(signState, nil)
+			err = pv.Save(signState, nil, false)
+			if err != nil {
+				fmt.Printf("error saving privval sign state")
+				return err
+			}
+			err = share.Save(signState, nil, false)
+			if err != nil {
+				fmt.Printf("error saving share sign state")
+				return err
+			}
+			return nil
+		},
+	}
+}
+
+func importStateCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "import [height]",
+		Aliases: []string{"i"},
+		Short: "Read the old priv_validator_state.json and set the height, round and step" +
+			"(good for migrations but NOT shared state update)",
+		Args:         cobra.ExactArgs(0),
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if _, err := os.Stat(config.HomeDir); os.IsNotExist(err) {
+				cmd.SilenceUsage = false
+				return fmt.Errorf("%s does not exist, initialize config with horcrux config init and try again", config.HomeDir)
+			}
+
+			// Resetting the priv_validator_state.json should only be allowed if the
+			// signer is not running.
+			if err := signer.RequireNotRunning(config.PidFile); err != nil {
+				return err
+			}
+
+			// Recreate privValStateFile if necessary
+			pv, err := signer.LoadOrCreateSignState(config.privValStateFile(config.Config.ChainID))
+			if err != nil {
+				return err
+			}
+
+			// shareStateFile does not exist during default config init, so create if necessary
+			share, err := signer.LoadOrCreateSignState(config.shareStateFile(config.Config.ChainID))
+			if err != nil {
+				return err
+			}
+
+			// Allow user to paste in priv_validator_state.json
+
+			fmt.Println("IMPORTANT: Your validator should already be STOPPED.  You must copy the latest state..")
+			<-time.After(2 * time.Second)
+			fmt.Println("")
+			fmt.Println("Paste your old priv_validator_state.json.  Input a blank line after the pasted JSON to continue.")
+			fmt.Println("")
+
+			var textBuffer strings.Builder
+
+			scanner := bufio.NewScanner(os.Stdin)
+			for scanner.Scan() {
+				if len(scanner.Text()) == 0 {
+					break
+				}
+				textBuffer.WriteString(scanner.Text())
+			}
+			finalJSON := textBuffer.String()
+
+			pvState := &FilePVLastSignState{}
+
+			err = tmjson.Unmarshal([]byte(finalJSON), &pvState)
+			if err != nil {
+				fmt.Println("Error parsing priv_validator_state.json")
+				return err
+			}
+
+			pv.EphemeralPublic = nil
+			signState := signer.SignStateConsensus{
+				Height:    pvState.Height,
+				Round:     int64(pvState.Round),
+				Step:      pvState.Step,
+				Signature: nil,
+				SignBytes: nil,
+			}
+			fmt.Printf("Saving New Sign State: \n"+
+				"  Height:    %v\n"+
+				"  Round:     %v\n"+
+				"  Step:      %v\n",
+				signState.Height, signState.Round, signState.Step)
+
+			err = pv.Save(signState, nil, false)
+			if err != nil {
+				fmt.Printf("error saving privval sign state")
+				return err
+			}
+			err = share.Save(signState, nil, false)
+			if err != nil {
+				fmt.Printf("error saving share sign state")
+				return err
+			}
+			fmt.Printf("Update Successful\n")
 			return nil
 		},
 	}

--- a/cmd/horcrux/cmd/state_test.go
+++ b/cmd/horcrux/cmd/state_test.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -23,7 +23,7 @@ func TestStateSetCmd(t *testing.T) {
 	require.NoError(t, err)
 
 	cmd := initCmd()
-	cmd.SetOutput(ioutil.Discard)
+	cmd.SetOutput(io.Discard)
 	cmd.SetArgs([]string{
 		chainid,
 		"tcp://10.168.0.1:1234",
@@ -55,7 +55,7 @@ func TestStateSetCmd(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			cmd := setStateCmd()
-			cmd.SetOutput(ioutil.Discard)
+			cmd.SetOutput(io.Discard)
 			cmd.SetArgs(tc.args)
 			err = cmd.Execute()
 

--- a/cmd/horcrux/cmd/version.go
+++ b/cmd/horcrux/cmd/version.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/cmd/horcrux/main.go
+++ b/cmd/horcrux/main.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/signer/cosigner_key.go
+++ b/signer/cosigner_key.go
@@ -4,7 +4,7 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/json"
-	"io/ioutil"
+	"os"
 
 	amino "github.com/tendermint/go-amino"
 	tmCrypto "github.com/tendermint/tendermint/crypto"
@@ -120,7 +120,7 @@ func (cosignerKey *CosignerKey) UnmarshalJSON(data []byte) error {
 // LoadCosignerKey loads a CosignerKey from file.
 func LoadCosignerKey(file string) (CosignerKey, error) {
 	pvKey := CosignerKey{}
-	keyJSONBytes, err := ioutil.ReadFile(file)
+	keyJSONBytes, err := os.ReadFile(file)
 	if err != nil {
 		return pvKey, err
 	}

--- a/signer/cosigner_key_shares.go
+++ b/signer/cosigner_key_shares.go
@@ -4,7 +4,7 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"encoding/json"
-	"io/ioutil"
+	"os"
 
 	tmjson "github.com/tendermint/tendermint/libs/json"
 	"github.com/tendermint/tendermint/privval"
@@ -42,7 +42,7 @@ func CreateCosignerShares(pv privval.FilePVKey, threshold, shares int64) (out []
 // ReadPrivValidatorFile reads in a privval.FilePVKey from a given file
 func ReadPrivValidatorFile(priv string) (out privval.FilePVKey, err error) {
 	var bz []byte
-	if bz, err = ioutil.ReadFile(priv); err != nil {
+	if bz, err = os.ReadFile(priv); err != nil {
 		return
 	}
 	if err = tmjson.Unmarshal(bz, &out); err != nil {
@@ -57,7 +57,7 @@ func WriteCosignerShareFile(cosigner CosignerKey, file string) error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(file, jsonBytes, 0644) // nolint
+	return os.WriteFile(file, jsonBytes, 0644) //nolint
 }
 
 func makeRSAKeys(num int) (rsaKeys []*rsa.PrivateKey, pubKeys []*rsa.PublicKey, err error) {

--- a/signer/local_cosigner.go
+++ b/signer/local_cosigner.go
@@ -109,7 +109,7 @@ type LocalCosigner struct {
 }
 
 func (cosigner *LocalCosigner) SaveLastSignedState(signState SignStateConsensus) error {
-	return cosigner.lastSignState.Save(signState, &cosigner.lastSignStateMutex)
+	return cosigner.lastSignState.Save(signState, &cosigner.lastSignStateMutex, true)
 }
 
 func NewLocalCosigner(cfg LocalCosignerConfig) *LocalCosigner {
@@ -229,7 +229,7 @@ func (cosigner *LocalCosigner) sign(req CosignerSignRequest) (CosignerSignRespon
 		Step:      hrst.Step,
 		Signature: sig,
 		SignBytes: req.SignBytes,
-	}, nil)
+	}, nil, true)
 
 	if err != nil {
 		if _, isSameHRSError := err.(*SameHRSError); !isSameHRSError {

--- a/signer/local_cosigner_test.go
+++ b/signer/local_cosigner_test.go
@@ -3,7 +3,6 @@ package signer
 import (
 	"crypto/rand"
 	"crypto/rsa"
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -80,7 +79,7 @@ func TestLocalCosignerSign2of2(t *testing.T) {
 		ID:       1,
 	}
 
-	stateFile1, err := ioutil.TempFile("", "state1.json")
+	stateFile1, err := os.CreateTemp("", "state1.json")
 	require.NoError(t, err)
 	defer os.Remove(stateFile1.Name())
 
@@ -93,7 +92,7 @@ func TestLocalCosignerSign2of2(t *testing.T) {
 		ID:       2,
 	}
 
-	stateFile2, err := ioutil.TempFile("", "state2.json")
+	stateFile2, err := os.CreateTemp("", "state2.json")
 	require.NoError(t, err)
 	defer os.Remove(stateFile2.Name())
 	signState2, err := LoadOrCreateSignState(stateFile2.Name())
@@ -203,7 +202,7 @@ func TestLocalCosignerWatermark(t *testing.T) {
 			ID:       1,
 		}
 
-		stateFile1, err := ioutil.TempFile("", "state1.json")
+		stateFile1, err := os.CreateTemp("", "state1.json")
 		require.NoError(t, err)
 		defer os.Remove(stateFile1.Name())
 

--- a/signer/raft_store_test.go
+++ b/signer/raft_store_test.go
@@ -3,7 +3,6 @@ package signer
 import (
 	"crypto/rand"
 	"crypto/rsa"
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -15,7 +14,7 @@ import (
 // Test_StoreInMemOpenSingleNode tests that a command can be applied to the log
 // stored in RAM.
 func Test_StoreInMemOpenSingleNode(t *testing.T) {
-	tmpDir, _ := ioutil.TempDir("", "store_test")
+	tmpDir, _ := os.MkdirTemp("", "store_test")
 	defer os.RemoveAll(tmpDir)
 
 	dummyPub := tmCryptoEd25519.PubKey{}

--- a/signer/threshold_validator.go
+++ b/signer/threshold_validator.go
@@ -75,11 +75,11 @@ func NewThresholdValidator(opt *ThresholdValidatorOpt) *ThresholdValidator {
 }
 
 func (pv *ThresholdValidator) SaveLastSignedState(signState SignStateConsensus) error {
-	return pv.lastSignState.Save(signState, &pv.lastSignStateMutex)
+	return pv.lastSignState.Save(signState, &pv.lastSignStateMutex, true)
 }
 
 func (pv *ThresholdValidator) SaveLastSignedStateInitiated(signState SignStateConsensus) error {
-	return pv.lastSignStateInitiated.Save(signState, &pv.lastSignStateInitiatedMutex)
+	return pv.lastSignStateInitiated.Save(signState, &pv.lastSignStateInitiatedMutex, true)
 }
 
 // GetPubKey returns the public key of the validator.
@@ -460,7 +460,7 @@ func (pv *ThresholdValidator) SignBlock(chainID string, block *Block) ([]byte, t
 		SignBytes: signBytes,
 	}
 	// Err will be present if newLss is not above high watermark
-	err = pv.lastSignState.Save(newLss, &pv.lastSignStateMutex)
+	err = pv.lastSignState.Save(newLss, &pv.lastSignStateMutex, true)
 	if err != nil {
 		if _, isSameHRSError := err.(*SameHRSError); !isSameHRSError {
 			return nil, stamp, err

--- a/signer/threshold_validator_test.go
+++ b/signer/threshold_validator_test.go
@@ -5,7 +5,6 @@ import (
 	"crypto/rsa"
 	"time"
 
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -61,7 +60,7 @@ func TestThresholdValidator2of2(t *testing.T) {
 		ID:       1,
 	}
 
-	stateFile1, err := ioutil.TempFile("", "state1.json")
+	stateFile1, err := os.CreateTemp("", "state1.json")
 	require.NoError(t, err)
 	defer os.Remove(stateFile1.Name())
 
@@ -74,7 +73,7 @@ func TestThresholdValidator2of2(t *testing.T) {
 		ID:       2,
 	}
 
-	stateFile2, err := ioutil.TempFile("", "state2.json")
+	stateFile2, err := os.CreateTemp("", "state2.json")
 	require.NoError(t, err)
 	defer os.Remove(stateFile2.Name())
 	signState2, err := LoadOrCreateSignState(stateFile2.Name())
@@ -110,7 +109,7 @@ func TestThresholdValidator2of2(t *testing.T) {
 	thresholdPeers := make([]Cosigner, 0)
 	thresholdPeers = append(thresholdPeers, cosigner2)
 
-	tmpDir, _ := ioutil.TempDir("", "store_test")
+	tmpDir, _ := os.MkdirTemp("", "store_test")
 	defer os.RemoveAll(tmpDir)
 
 	raftStore := getMockRaftStore(cosigner1, tmpDir)
@@ -184,7 +183,7 @@ func TestThresholdValidator3of3(t *testing.T) {
 		ID:       1,
 	}
 
-	stateFile1, err := ioutil.TempFile("", "state1.json")
+	stateFile1, err := os.CreateTemp("", "state1.json")
 	require.NoError(t, err)
 	defer os.Remove(stateFile1.Name())
 
@@ -197,7 +196,7 @@ func TestThresholdValidator3of3(t *testing.T) {
 		ID:       2,
 	}
 
-	stateFile2, err := ioutil.TempFile("", "state2.json")
+	stateFile2, err := os.CreateTemp("", "state2.json")
 	require.NoError(t, err)
 	defer os.Remove(stateFile2.Name())
 
@@ -210,7 +209,7 @@ func TestThresholdValidator3of3(t *testing.T) {
 		ID:       3,
 	}
 
-	stateFile3, err := ioutil.TempFile("", "state3.json")
+	stateFile3, err := os.CreateTemp("", "state3.json")
 	require.NoError(t, err)
 	defer os.Remove(stateFile3.Name())
 
@@ -259,7 +258,7 @@ func TestThresholdValidator3of3(t *testing.T) {
 	thresholdPeers := make([]Cosigner, 0)
 	thresholdPeers = append(thresholdPeers, cosigner2, cosigner3)
 
-	tmpDir, _ := ioutil.TempDir("", "store_test")
+	tmpDir, _ := os.MkdirTemp("", "store_test")
 	defer os.RemoveAll(tmpDir)
 
 	raftStore := getMockRaftStore(cosigner1, tmpDir)
@@ -336,7 +335,7 @@ func TestThresholdValidator2of3(t *testing.T) {
 		ID:       1,
 	}
 
-	stateFile1, err := ioutil.TempFile("", "state1.json")
+	stateFile1, err := os.CreateTemp("", "state1.json")
 	require.NoError(t, err)
 	defer os.Remove(stateFile1.Name())
 
@@ -349,7 +348,7 @@ func TestThresholdValidator2of3(t *testing.T) {
 		ID:       2,
 	}
 
-	stateFile2, err := ioutil.TempFile("", "state2.json")
+	stateFile2, err := os.CreateTemp("", "state2.json")
 	require.NoError(t, err)
 	defer os.Remove(stateFile2.Name())
 
@@ -362,7 +361,7 @@ func TestThresholdValidator2of3(t *testing.T) {
 		ID:       3,
 	}
 
-	stateFile3, err := ioutil.TempFile("", "state3.json")
+	stateFile3, err := os.CreateTemp("", "state3.json")
 	require.NoError(t, err)
 	defer os.Remove(stateFile3.Name())
 
@@ -411,7 +410,7 @@ func TestThresholdValidator2of3(t *testing.T) {
 	thresholdPeers := make([]Cosigner, 0)
 	thresholdPeers = append(thresholdPeers, cosigner2, cosigner3)
 
-	tmpDir, _ := ioutil.TempDir("", "store_test")
+	tmpDir, _ := os.MkdirTemp("", "store_test")
 	defer os.RemoveAll(tmpDir)
 
 	raftStore := getMockRaftStore(cosigner1, tmpDir)

--- a/test/test_setup.go
+++ b/test/test_setup.go
@@ -157,7 +157,7 @@ func Genesis(
 	}
 
 	for i := 1; i < len(nodes); i++ {
-		if err := os.WriteFile(nodes[i].GenesisFilePath(), genbz, 0644); err != nil { // nolint
+		if err := os.WriteFile(nodes[i].GenesisFilePath(), genbz, 0644); err != nil { //nolint
 			return err
 		}
 	}

--- a/test/test_signer.go
+++ b/test/test_signer.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path"
 	"path/filepath"
@@ -45,7 +45,7 @@ func BuildTestSignerImage(pool *dockertest.Pool) error {
 	return pool.Client.BuildImage(docker.BuildImageOptions{
 		Name:                signerImage,
 		Dockerfile:          dockerfile,
-		OutputStream:        ioutil.Discard,
+		OutputStream:        io.Discard,
 		SuppressOutput:      false,
 		Pull:                false,
 		RmTmpContainer:      true,
@@ -117,7 +117,7 @@ func StartSingleSignerContainers(
 // shard the validator's priv_validator_key.json key, write the sharded key shares to the appropriate
 // signer nodes directory and start the signer cluster.
 // NOTE: Zero or negative values for sentriesPerSigner configures the nodes in the signer cluster to connect to the
-//       same sentry node.
+// same sentry node.
 func StartCosignerContainers(
 	signers TestSigners,
 	sentries TestNodes,


### PR DESCRIPTION
…… (#92)

* Make migrations easier by allowing cut and paste state height/round/step import

* make golintci and gofmt happy

* Upgrade ioutil to io and os packages

* Fix async sign state save for CLI methods

* Create state files as necessary

Co-authored-by: Andrew Gouin <andrew@gouin.io>