### PR TITLE
Threshold parameter validation (#112)

### DIFF
--- a/cmd/horcrux/cmd/key2shares_test.go
+++ b/cmd/horcrux/cmd/key2shares_test.go
@@ -1,0 +1,71 @@
+package cmd
+
+import (
+	"io"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tendermint/tendermint/crypto/ed25519"
+	"github.com/tendermint/tendermint/privval"
+)
+
+func TestKey2Shares(t *testing.T) {
+	tmp := t.TempDir()
+
+	privValidatorKeyFile := filepath.Join(tmp, "priv_validator_key.json")
+	privValidatorStateFile := filepath.Join(tmp, "priv_validator_state.json")
+	pv := privval.NewFilePV(ed25519.GenPrivKey(), privValidatorKeyFile, privValidatorStateFile)
+	pv.Save()
+
+	tcs := []struct {
+		name      string
+		args      []string
+		expectErr bool
+	}{
+		{
+			name:      "valid threshold and shares",
+			args:      []string{privValidatorKeyFile, "2", "3"},
+			expectErr: false,
+		},
+		{
+			name:      "valid threshold and shares 2",
+			args:      []string{privValidatorKeyFile, "3", "5"},
+			expectErr: false,
+		},
+		{
+			name:      "threshold exactly half of shares",
+			args:      []string{privValidatorKeyFile, "2", "4"},
+			expectErr: true,
+		},
+		{
+			name:      "threshold less than half of shares",
+			args:      []string{privValidatorKeyFile, "1", "3"},
+			expectErr: true,
+		},
+		{
+			name:      "threshold exceeds shares",
+			args:      []string{privValidatorKeyFile, "4", "3"},
+			expectErr: true,
+		},
+		{
+			name:      "non-numeric threshold and shares",
+			args:      []string{privValidatorKeyFile, "two", "three"},
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := CreateCosignerSharesCmd()
+			cmd.SetOutput(io.Discard)
+			cmd.SetArgs(tc.args)
+			err := cmd.Execute()
+			if tc.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/cmd/horcrux/cmd/state_test.go
+++ b/cmd/horcrux/cmd/state_test.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"io"
-	"os"
 	"path/filepath"
 	"strconv"
 	"testing"
@@ -13,14 +12,11 @@ import (
 )
 
 func TestStateSetCmd(t *testing.T) {
-	tmpHome := "/tmp/TestStateSetCmd"
+	tmpHome := t.TempDir()
 	tmpConfig := filepath.Join(tmpHome, ".horcrux")
 	chainid := "horcrux-1"
 
-	err := os.Setenv("HOME", tmpHome)
-	require.NoError(t, err)
-	err = os.MkdirAll(tmpHome, 0777)
-	require.NoError(t, err)
+	t.Setenv("HOME", tmpHome)
 
 	cmd := initCmd()
 	cmd.SetOutput(io.Discard)
@@ -28,11 +24,12 @@ func TestStateSetCmd(t *testing.T) {
 		chainid,
 		"tcp://10.168.0.1:1234",
 		"-c",
+		"-t", "2",
 		"-p", "tcp://10.168.1.2:2222|2,tcp://10.168.1.3:2222|3",
 		"-l", "tcp://10.168.1.1:2222",
 		"--timeout", "1500ms",
 	})
-	err = cmd.Execute()
+	err := cmd.Execute()
 	require.NoError(t, err)
 
 	tcs := []struct {
@@ -89,8 +86,4 @@ func TestStateSetCmd(t *testing.T) {
 			}
 		})
 	}
-
-	t.Cleanup(func() {
-		os.RemoveAll(tmpHome)
-	})
 }


### PR DESCRIPTION
* Add assertions for t > n/2 for both key sharding and cosigner daemon start

* Show container logs for failed tests

* Update tests

* Fix set state test

* Prefer t.Setenv in tests. Fix error message